### PR TITLE
Fix lsscsi wwn number output error

### DIFF
--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -1515,7 +1515,7 @@ collect_disk_wwn_nodes(void)
 
                 cur_ent = &cur_list->nodes[cur_list->count];
                 my_strcopy(cur_ent->wwn, "0x", 3);
-                my_strcopy(cur_ent->wwn + 2, dep->d_name + 5,
+                my_strcopy(cur_ent->wwn + 2, dep->d_name + 6,
                            sizeof(cur_ent->wwn) - 2);
                 my_strcopy(cur_ent->disk_bname, basename(symlink_path),
                            sizeof(cur_ent->disk_bname));


### PR DESCRIPTION
current lsscsi -w output the wrong wwn id like following
$ lsscsi -w 
[3:0:0:2]    disk    LIO-ORG  disk2            4.0   0x36001405a7da98a3af35412a96c5576a  /dev/sdc 

the correct id should be
$ udevadm info --export-db | grep WWN
E: ID_WWN=0x6001405a7da98a3a
E: ID_WWN_VENDOR_EXTENSION=0xf35412a96c5576a2
E: ID_WWN_WITH_EXTENSION=0x6001405a7da98a3af35412a96c5576a2