### PR TITLE
Fix multipath WWID inconsistencies in lsscsi

### DIFF
--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -1902,7 +1902,63 @@ get_disk_scsi_id(const char *dev_node, bool no_prefix, int recurse_count,
         struct dirent *entry;
         char holder[LMAX_PATH + 6];
         char sys_block[LMAX_PATH];
+        char sysfs_path[LMAX_PATH];
+        char sysfs_wwid[LMAX_NAME];
 
+        /* Use the sysfs wwid as a key to locate the corresponding udev-created
+         * /dev/disk/by-id/scsi-* symlink directly, rather than scanning the
+         * directory and matching by sd_rdev. For multipath, all path share
+         * the same WWID so all find the by-id symlink and return the same
+         * identifier, fixing the inconsistency. The output value remains
+         * strictly udev-derived: sysfs is used only to know which symlink to
+         * look for, the symlink must exist in the udev-managed by-id directory
+         * before we return its name.
+         *
+         * SCSI name string is excluded: the sysfs wwid is the raw
+         * IQN whereas the by-id symlink stores a hex-encoded form.
+         *
+         * Fall through if sysfs is unavailable, if the expected symlink does
+         * not exist, or for dm-uuid-mpath-*, usb-* and SCSI name string types.
+         */
+        snprintf(sysfs_path, sizeof(sysfs_path), "%s/class/block/%s/device",
+                 sysfsroot, dev_node + 5);
+        if (get_value(sysfs_path, "wwid", sysfs_wwid, sizeof(sysfs_wwid)) &&
+            sysfs_wwid[0] != '\0') {
+                if (0 == strncmp(sysfs_wwid, "naa.", 4) ||
+                    0 == strncmp(sysfs_wwid, "eui.", 4)) {
+                        char desig = ('n' == sysfs_wwid[0]) ? '3' : '2';
+                        const char *id_str = sysfs_wwid + 4;
+                        char byid_path[LMAX_PATH];
+                        struct stat st;
+
+                        /* Build the expected by-id path and confirm the
+                         * symlink exists there before using its name.
+                         */
+                        snprintf(byid_path, sizeof(byid_path), "%s/scsi-%c%s",
+                                 dev_disk_byid_dir, desig, id_str);
+                        if (lstat(byid_path, &st) == 0 &&
+                            S_ISLNK(st.st_mode)) {
+                                if (no_prefix) {
+                                        scsi_id = strdup(id_str);
+                                } else {
+                                        size_t len = strlen(id_str) + 2;
+
+                                        scsi_id = (char *)malloc(len);
+                                        if (scsi_id) {
+                                                scsi_id[0] = desig;
+                                                my_strcopy(scsi_id +1, id_str,
+                                                           len -1);
+                                        }
+                                }
+                                if (scsi_id)
+                                        goto out;
+                        }
+                }
+        }
+
+        /* Fall back to /dev/disk/by-id/ scan for older kernels and for
+         * dm-uuid-mpath-*, usb-* and SCSI name string device types.
+         */
         scsi_id = lookup_dev(dev_disk_byid_dir, "scsi-", "328S10", dev_node);
         if (scsi_id) {
                 if (no_prefix) {

--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -1570,6 +1570,27 @@ fini:
         return match_found;
 }
 
+/* Returns true if an entry with a matching disk_bname already exists in the
+ * collected WWN node list. Used by collect_disk_wwn_nodes() to enforce by
+ * designator-type priority ordering across the readdir() sequence. */
+
+static bool
+wwn_bname_in_list(const char *disk_bname)
+{
+        unsigned int k;
+        struct disk_wwn_node_list *cur_list = disk_wwn_node_listhead;
+        
+        while (cur_list) {
+                for (k = 0; k < cur_list->count; ++k) {
+                        if (0 == strcmp(cur_list->nodes[k].disk_bname,
+                                        disk_bname))
+                                return true;
+                }
+                cur_list = cur_list->next;
+        }
+        return false;
+}
+
 /* Allocate disk_wwn_node_list and collect info on every node in
  * /dev/disk/by-id/scsi-* that does not contain "part" . Returns
  * number of wwn nodes collected, 0 for already collected and
@@ -1578,6 +1599,7 @@ static int
 collect_disk_wwn_nodes(bool wwn_twice)
 {
         int k;
+        int pass;
         int num = 0;
         size_t dwnl_sz = sizeof(struct disk_wwn_node_list);
         struct disk_wwn_node_list *cur_list, *prev_list;
@@ -1605,50 +1627,81 @@ collect_disk_wwn_nodes(bool wwn_twice)
         if (wwn_twice)
                 goto wwn_really;
 
-        while (1) {
-                dep = readdir(dirp);
-                if (dep == NULL)
-                        break;
-                if (memcmp("scsi-", dep->d_name, 5))
-                        continue;       /* needs to start with "scsi-" */
-                if (strstr(dep->d_name, "part"))
-                        continue;       /* skip if contains "part" */
-                /* accepted device identification VPD page designator types */
-                if (dep->d_name[5] != '3' &&    /* NAA */
-                    dep->d_name[5] != '2' &&    /* EUI-64 based */
-                    dep->d_name[5] != '8')      /* SCSI name string (iSCSI) */
-                        continue;       /* skip for invalid identifier */
+        /* Scan /dev/disk/by-id/scsi-* in three passes, once per designator
+         * type in the priority order: NAA (3) > EUI-64 (2) > SCSI name string
+         * (8). rewinddir() is used between passes so the directory is re-read
+         * from the start each time.
+         *
+         * For each pass, wwn_bname_in_list() skips any device that already
+         * has an entry from a higher-priority pass. This ensures consistent
+         * designator type selection for each device regardless of the non-
+         * deterministic ordering readir() may produce.
+         */
+        static const char desig_priority[] = { '3', '2', '8' };
 
-                snprintf(device_path, PATH_MAX, "%s/%s", dev_disk_byid_dir,
-                         dep->d_name);
-                device_path[PATH_MAX] = '\0';
-                if (lstat(device_path, &stats))
-                        continue;       /* unlikely: error */
-                if (! S_ISLNK(stats.st_mode))
-                        continue;       /* Skip non-symlinks */
-                if ((k = readlink(device_path, symlink_path, PATH_MAX)) < 1)
-                        continue;       /* expect 1 or more chars in symlink */
-                symlink_path[k] = '\0';
-
-                /* Add to the list. */
-                if (cur_list->count >= DISK_WWN_NODE_LIST_ENTRIES) {
-                        prev_list = cur_list;
-                        cur_list = (struct disk_wwn_node_list *)
-                                                        calloc(1, dwnl_sz);
-                        if (! cur_list)
+        for (pass = 0; pass < 3; ++pass) {
+                const char desig = desig_priority[pass];
+                char bname[LMAX_NAME];
+                
+                if (!cur_list)
+                        break; /* calloc failed in prior pass */
+                rewinddir(dirp);
+                while(1) {
+                        dep = readdir(dirp);
+                        if (dep == NULL)
                                 break;
-                        prev_list->next = cur_list;
-                }
+                        if (memcmp("scsi-", dep->d_name, 5))
+                                continue;        /* needs to start with "scsi-" */
+                        if (strstr(dep->d_name, "part"))
+                                continue;        /* skip if contains "part" */
+                        if (dep->d_name[5] != desig)
+                                continue;        /* this passes designator only */
 
-                cur_ent = &cur_list->nodes[cur_list->count];
-                my_strcopy(cur_ent->wwn, "0x", 3);
-                /* step over designator type */
-                my_strcopy(cur_ent->wwn + 2, dep->d_name + 6,
-                           sizeof(cur_ent->wwn) - 2);
-                my_strcopy(cur_ent->disk_bname, basename(symlink_path),
-                           sizeof(cur_ent->disk_bname));
-                cur_list->count++;
-                ++num;
+                        snprintf(device_path, PATH_MAX, "%s/%s",
+                                 dev_disk_byid_dir, dep->d_name);
+                        device_path[PATH_MAX] = '\0';
+                        if (lstat(device_path, &stats))
+                                continue;        /* unlikely: error */
+                        if (! S_ISLNK(stats.st_mode))
+                                continue;        /* skip non-symlinks */
+                        if ((k = readlink(device_path, symlink_path,
+                                          PATH_MAX)) < 1)
+                                continue;        /* we expect 1 or more chars in symlnk */
+                        symlink_path[k] = '\0';
+                    
+                        /* basename() may modify its argument; copy result
+                         * before using it in wwn_bname_in_list() and in
+                         * my_strcopy() below. */
+                        my_strcopy(bname, basename(symlink_path),
+                                   sizeof(bname));
+                    
+                        /* Skip if a higher-priority entry already exists for
+                         * this device (e.g. NAA found on pass 0, now seeing
+                         * an EUI-64 for the same disk on pass 1). */
+                        if (wwn_bname_in_list(bname))
+                            continue;
+                    
+                        /* Add item to list. */
+                        if (cur_list->count >= DISK_WWN_NODE_LIST_ENTRIES) {
+                                prev_list = cur_list;
+                                cur_list = (struct disk_wwn_node_list *)
+                                                        calloc(1, dwnl_sz);
+
+                                if (! cur_list)
+                                        break;
+                                prev_list->next = cur_list;
+                        }
+                        
+                        cur_ent = &cur_list->nodes[cur_list->count];
+                        my_strcopy(cur_ent->wwn, "0x", 3);
+                        /* step over designator type */
+                        my_strcopy(cur_ent->wwn + 2, dep->d_name + 6,
+                                   sizeof(cur_ent->wwn) - 2);
+                        my_strcopy(cur_ent->disk_bname, bname,
+                                   sizeof(cur_ent->disk_bname));
+                        cur_list->count++;
+                        ++num;
+                }
         }
         closedir(dirp);
         return num;

--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -1724,10 +1724,35 @@ get_disk_wwn(const char *wd, char * wwn_str, int max_wwn_str_len,
         struct disk_wwn_node_list *cur_list;
         struct disk_wwn_node_entry *cur_ent;
         char name[LMAX_PATH];
+        char sysfs_path[LMAX_PATH];
+        char sysfs_wwid[LMAX_NAME];
 
         my_strcopy(name, wd, sizeof(name));
         name[sizeof(name) - 1] = '\0';
         bn = basename(name);
+
+        /* Prefer the per-device sysfs wwid attribute (available since
+         * Linux 3.15) over /dev/disk/by-id/ symlink scan. For multipath,
+         * each path has its own sysfs entry so all paths will reliably
+         * report their WWID.
+         */
+        snprintf(sysfs_path, sizeof(sysfs_path),
+                 "%s/class/block/%s/device", sysfsroot, bn);
+        if (get_value(sysfs_path, "wwid", sysfs_wwid, sizeof(sysfs_wwid)) &&
+            sysfs_wwid[0] != '\0') {
+                /* sysfs uses "naa.<hex>" / "eui.<hex>" prefixes. Convert
+                 * to the expected "0x<hex>" form used by the rest of the
+                 * method. */
+                if (0 == strncmp(sysfs_wwid, "naa.", 4) ||
+                    0 == strncmp(sysfs_wwid, "eui.", 4)) {
+                        snprintf(wwn_str, max_wwn_str_len, "0x%.*s",
+                                 max_wwn_str_len -3, sysfs_wwid + 4);
+                        wwn_str[max_wwn_str_len -1] = '\0';
+                        return true;
+                }
+        }
+
+        /* Fall back to /dev/disk/by-id/ scan for older kernels. */
         if (disk_wwn_node_listhead == NULL) {
                 collect_disk_wwn_nodes(wwn_twice);
                 if (disk_wwn_node_listhead == NULL)

--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -1990,6 +1990,9 @@ get_disk_scsi_id(const char *dev_node, bool no_prefix, int recurse_count,
         if (!dir)
                 goto out;
         while ((entry = readdir(dir)) != NULL) {
+                if ('.' == entry->d_name[0])
+                        continue;        /* skip "." and ".." */
+
                 snprintf(holder, sizeof(holder), "/dev/%s", entry->d_name);
                 /* recurse */
                 scsi_id = get_disk_scsi_id(holder, no_prefix,


### PR DESCRIPTION
With multipath configurations udev can only maintain a single /dev/disk/by-id/scsi-* symlink per WWID. As a result "lsscsi -w" and "lssscsi -i" report an identifier only for the path currently targeted by the symlink, all other paths return no result.

This patchset addresses the issue by reading the per-device sysfs wwid attribute, which provides a stable, per-path identifier not subject to symlink contention. The existing /dev/disk/by-id/ directory scan is retained as a fallback for older kernels and for device types where the sysfs value cannot be mapped directly to a by-id symlink name (T10, SCSI name string, USB, dm-mpath).

Additionally, the by-id scan in collect_disk_wnn_nodes() is modified to select designator types in a defined priority order (NAA > EUI-64 > SCSI name string), eliminating dependency on non-deterministic readdir() ordering.

Patches:
1). get_disk_wwn: prefer sysfs wwid over /dev/disk/by-id/ symlink scan:
Read /sys/class/block/*dev*/device/wwid for naa./eui. devices in "lsscsi -w", falling back to the by-id scan for other types and older kernels.

2). collect_disk_wwn_nodes: three-pass scan with designator-type priority ordering:
Scan /dev/disk/by-id/scsi-* in priority order (NAA > EUI-64 > SCSI name string) so designator selection is deterministic regardless of readdir() ordering.

3). get_disk_scsi_id: use sysfs wwid to locate by-id symlink for multipath consistency:
Use the sysfs wwid to construct the expected by-id symlink name for "lsscsi -i", confirming the symlink exists in the udev-managed directory before returning its name.

4). get_disk_scsi_id: skip dot entries during holders scan:
Skip "." and ".." in the holders readdir() loop to avoid wasted recursive calls.

Resolves #2 