### PR TITLE
debian: migrate from cdbs to debhelper (compatibility level 10)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,13 @@ Source: lsscsi
 Section: admin
 Priority: optional
 Maintainer: Matt Taggart <taggart@debian.org>
-Build-Depends: cdbs (>= 0.4.15), debhelper (>= 4.0.0), autotools-dev
-Standards-Version: 3.6.2.1
+Build-Depends: debhelper (>= 10), autoconf, automake
+Standards-Version: 4.7.0
+Rules-Requires-Root: no
 
 Package: lsscsi
 Architecture: any
-Depends: ${shlibs:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: list all SCSI devices and NVMe namespaces currently on system
  Uses information provided by the sysfs pseudo file system in the Linux
  kernel 2.6 series, and later, to list SCSI devices (Logical

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,3 @@
 #!/usr/bin/make -f
-include /usr/share/cdbs/1/rules/buildcore.mk
-include /usr/share/cdbs/1/class/autotools.mk
-include /usr/share/cdbs/1/rules/debhelper.mk
-#include /usr/share/cdbs/1/rules/simple-patchsys.mk
+%:
+	dh $@


### PR DESCRIPTION
Replace the deprecated cdbs build system with the standard deb helper sequencer. The cdbs package is no longer commonly available on modern Debian/Ubuntu systems, causing build failures due to missing /usr/share/cdbs/1/class/autotools.mk.

debian/rules: replace cdbs includes with minimal dh target.

debian/control: replace cdbs and autotools-dev build dependencies with debhelper (>= 10), autoconf and automake.

Add ${misc:Depends} to binary package Depends as required by debhelper.

Add Rules-Requires-Root: no since the build does not require root privileges.

Bump Standards-Version from 3.6.2.1 to 4.7.0.