### PR TITLE
ls_name_value: fix portability issue and misc fd fix

### DIFF
--- a/scripts/ls_name_value
+++ b/scripts/ls_name_value
@@ -297,8 +297,8 @@ while :; do
   esac
 done
 
-if which -s "${ls_bin}" ; then
-  ls_bin=$( which "${ls_bin}" )
+if command -v "${ls_bin}" > /dev/null 2>&1 ; then
+  ls_bin=$( command -v "${ls_bin}" )
   ls_args+=( "${ls_bin}" )
   if [ "${all}" -gt 0 ] ; then
     if [ "${native_order}" -gt 0 ] ; then
@@ -323,9 +323,9 @@ fi
 
 # In production ${content_reader} is expected to be on $PATH.
 # In development it should be found in a sibling directory.
-if ! which -s "${content_reader}" ; then
+if ! command -v "${content_reader}" > /dev/null 2>&1 ; then
   dev_content_reader="../src/${content_reader}"
-  if which -s "${dev_content_reader}" ; then
+  if [ -x "${dev_content_reader}" ] ; then
     content_reader=$(pwd)/"${dev_content_reader}"
   else
     echo "Unable to find helper: ${content_reader}, exiting"

--- a/src/ls_name_value_rd.c
+++ b/src/ls_name_value_rd.c
@@ -292,7 +292,6 @@ main(int argc, char * argv[])
             if (verbose > 0)
                 fprintf(stderr, "<fstat() bad file descriptor>");
             err = 0;
-            fd = -1;
             goto cleanup;
         } else {
             if (verbose > 0)


### PR DESCRIPTION
scripts/ls_name_value: replace 'which -s' with 'command -v' as the -s (silent) flag is not supported on Linux, causing "invalid option" errors on systems where which does not recognise it.

Fix a file descriptor leak on the fstat EBADF error path where fd was set to -1 before reaching the cleanup block, causing close() to be skipped on the originally opened file descriptor.