### PR TITLE
Misc Fixups: memory leaks, null termination, and bounds checking

### DIFF
--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -6196,8 +6196,10 @@ main(int argc, char **argv)
                         }
                 }
                 if (l_sysfsroot) {
-                        if (l_fsroot_sz > 1)
+                        if (l_fsroot_sz > 1) {
                                 strncpy(sysfsroot, l_sysfsroot, l_fsroot_sz);
+                                sysfsroot[l_fsroot_sz] = '\0';
+                        }
                 } else if (l_root_sz > 1) {
                         int n = l_root_sz;
                         static const char * sysfs_dir = "/sys";
@@ -6207,11 +6209,13 @@ main(int argc, char **argv)
                         if ((n > 1) && ('/' == sysfsroot[n - 1]))
                             --n;
                         memcpy(sysfsroot + n, sysfs_dir, 4);
+                        sysfsroot[n + 4] = '\0';
                         n = l_root_sz;
                         strncpy(devfsroot, l_sysroot, devfsroot_sz - 1);
                         if ((n > 1) && ('/' == devfsroot[n - 1]))
                             --n;
                         memcpy(devfsroot + n, devfs_dir, 4);
+                        devfsroot[n + 4] = '\0';
                         if (op->verbose > 1)
                                 pr2serr("Alternate devfs root: %s\n",
                                         devfsroot);

--- a/src/lsscsi.c
+++ b/src/lsscsi.c
@@ -504,7 +504,7 @@ trim_lead_trail(char * s, bool trim_leading, bool trim_trailing)
                 return s ? (int)strlen(s) : 0;
 
         if (trim_trailing) {
-                while (isspace((uint8_t)p[n - 1]))
+                while (n > 0 && isspace((uint8_t)p[n - 1]))
                         p[--n] = 0;
         }
         if (trim_leading) {

--- a/src/sg_json.c
+++ b/src/sg_json.c
@@ -348,7 +348,7 @@ sgj_js2file_estr(sgj_state * jsp, sgj_opaque_p jop, int exit_status,
             ccp = estr;
         else {
             if (0 == exit_status)
-                strncpy(d, "no errors", sizeof(d) - 1);
+                snprintf(d, sizeof(d), "no errors");
             else
                 snprintf(d, sizeof(d), "exit_status=%d", exit_status);
             ccp = d;
@@ -880,13 +880,15 @@ sgj_js_nv_ihexstr_nex(sgj_state * jsp, sgj_opaque_p jop, const char * sn_name,
                       int64_t val_i, bool hex_as_well, const char * str_name,
                       const char * val_s, const char * nex_s)
 {
-    bool as_hex = jsp->pr_hex && hex_as_well;
-    bool as_str = jsp->pr_string && val_s;
-    bool as_nex = jsp->pr_name_ex && nex_s;
-    const char * sname =  str_name ? str_name : sc_mn_s;
+    bool as_hex, as_str, as_nex;
+    const char * sname;
 
     if ((NULL == jsp) || (! jsp->pr_as_json))
         return;
+    as_hex = jsp->pr_hex && hex_as_well;
+    as_str = jsp->pr_string && val_s;
+    as_nex = jsp->pr_name_ex && nex_s;
+    sname = str_name ? str_name : sc_mn_s;
     if (! (as_hex || as_nex || as_str))
         sgj_js_nv_i(jsp, jop, sn_name, val_i);
     else {

--- a/src/sg_json.c
+++ b/src/sg_json.c
@@ -482,11 +482,17 @@ sgj_snake_named_subobject_r(sgj_state * jsp, sgj_opaque_p jop,
     if (jsp && jsp->pr_as_json && conv2sname) {
         int olen = strlen(conv2sname);
         char * sname = (char *)malloc(olen + 8);
-        int nlen = sgj_name_to_snake(conv2sname, sname, olen + 8);
+        sgj_opaque_p resp = NULL;
+        int nlen;
 
+        if (NULL == sname)
+            return NULL;
+        nlen = sgj_name_to_snake(conv2sname, sname, olen + 8);
         if (nlen > 0)
-            return json_object_push((json_value *)(jop ? jop : jsp->basep),
+            resp = json_object_push((json_value *)(jop ? jop : jsp->basep),
                                     sname, json_object_new(0));
+        free(sname);
+        return resp;
     }
     return NULL;
 }
@@ -510,11 +516,17 @@ sgj_snake_named_subarray_r(sgj_state * jsp, sgj_opaque_p jop,
     if (jsp && jsp->pr_as_json && conv2sname) {
         int olen = strlen(conv2sname);
         char * sname = (char *)malloc(olen + 8);
-        int nlen = sgj_name_to_snake(conv2sname, sname, olen + 8);
+        sgj_opaque_p resp = NULL;
+        int nlen;
 
+        if (NULL == sname)
+            return NULL;
+        nlen = sgj_name_to_snake(conv2sname, sname, olen + 8);
         if (nlen > 0)
-            return json_object_push((json_value *)(jop ? jop : jsp->basep),
+            resp = json_object_push((json_value *)(jop ? jop : jsp->basep),
                                     sname, json_array_new(0));
+        free(sname);
+        return resp;
     }
     return NULL;
 }


### PR DESCRIPTION
  lsscsi.c:
    - Add explicit null terminators after strncpy/memcpy when building
      sysfsroot and devfsroot from --sysfsroot and --sysroot arguments.
    - Add bounds check in trim_lead_trail() to prevent buffer under-read
      on all-whitespace strings.

  sg_json.c:
    - Fix memory leak in sgj_snake_named_subobject_r() and
      sgj_snake_named_subarray_r(): free the snake_case name buffer after
      json_object_push() makes its internal copy. Add NULL check on the
      malloc.
    - Replace strncpy with snprintf in sgj_js2file_estr() for consistent
      null termination.
    - Move NULL check before member dereferences in
      sgj_js_nv_ihexstr_nex() to prevent crash when jsp is NULL.